### PR TITLE
Add fix to hypersphere_overlap_of_subset

### DIFF
--- a/selector/diversity.py
+++ b/selector/diversity.py
@@ -375,15 +375,25 @@ def hypersphere_overlap_of_subset(x: np.ndarray, x_subset: np.array) -> float:
     Agrafiotis, D. K.. (1997) Stochastic Algorithms for Maximizing Molecular Diversity.
     Journal of Chemical Information and Computer Sciences 37, 841-851.
     """
-    d = len(x_subset[0])
-    k = len(x_subset[:, 0])
+
     # Find the maximum and minimum over each feature across all molecules.
     max_x = np.max(x, axis=0)
     min_x = np.min(x, axis=0)
-    # normalization of each feature to [0, 1]
-    if np.any(np.abs(max_x - min_x) < 1e-30):
-        raise ValueError("One of the features is redundant and causes normalization to fail.")
 
+    if np.all(np.abs(max_x - min_x) < 1e-30):
+        raise ValueError("All of the features are redundant which causes normalization to fail.")
+
+    # Remove redundant features
+    non_red_feat = np.abs(max_x - min_x) > 1e-30
+    x = x[:, non_red_feat]
+    x_subset = x_subset[:, non_red_feat]
+    max_x = max_x[non_red_feat]
+    min_x = min_x[non_red_feat]
+
+    d = len(x_subset[0])
+    k = len(x_subset[:, 0])
+
+    # normalization of each feature to [0, 1]
     x_norm = (x_subset - min_x) / (max_x - min_x)
 
     # r_o = hypersphere radius

--- a/selector/tests/test_diversity.py
+++ b/selector/tests/test_diversity.py
@@ -51,6 +51,8 @@ sample5 = np.array([[0, 2, 4, 0], [1, 2, 4, 0], [2, 2, 4, 0]])
 
 sample6 = np.array([[1, 0, 1, 0], [0, 1, 1, 0], [1, 0, 1, 0], [0, 0, 1, 0]])
 
+sample7 = np.array([[1, 0, 1, 0] for _ in range(4)])
+
 
 def test_compute_diversity_specified():
     """Test compute diversity with a specified div_type."""
@@ -231,7 +233,7 @@ def test_hypersphere_overlap_of_subset_with_only_corners_and_center():
 
 def test_hypersphere_normalization_error():
     """Test the hypersphere overlap method raises error when normalization fails."""
-    assert_raises(ValueError, hypersphere_overlap_of_subset, sample5, sample5)
+    assert_raises(ValueError, hypersphere_overlap_of_subset, sample7, sample7)
 
 
 def test_hypersphere_radius_warning():


### PR DESCRIPTION
The hypersphere_overlap_of_subset method failed if the data had any redundant feature. This is a pretty common case, e.g. finding a diverse set of alcohols (all binary chains will have a common feature). This was making grid_partitioning methods to fail.

The fix removes redundant coordinates before normalizing and computing diversity. Now it only fails if all binary chains in the data are the same.