### PR TITLE
New average similarity  method

### DIFF
--- a/selector/methods/similarity.py
+++ b/selector/methods/similarity.py
@@ -821,10 +821,20 @@ class SimilarityIndex:
         # For each sample in the set, calculate the columnwise sum of the data without the sample
         comp_sums = c_total - arr
 
+        # The medoid is calculated using an instance of the SimilarityIndex class with the same
+        # parameters as the current class, but with the inv_order = 1
+        si = SimilarityIndex(
+            method=self.method,
+            inv_order=1,
+            similarity_index=self.similarity_index,
+            c_threshold=self.c_threshold,
+            w_factor=self.w_factor,
+        )
+
         # for each sample calculate the similarity index of the complete set without the sample
         for idx, obj in enumerate(comp_sums):
             # calculate the similarity index of the set of objects without the current object
-            sim_index = self(obj, n_objects=n_objects - 1)
+            sim_index = si(obj, n_objects=n_objects - 1)
             # if the similarity is lower than the previous minimum similarity, update the minimum
             # similarity and the index
             if sim_index < min_sim:
@@ -880,10 +890,20 @@ class SimilarityIndex:
         # For each sample in the set, calculate the columnwise sum of the data without the sample
         comp_sums = c_total - arr
 
+        # The outlier is calculated using an instance of the SimilarityIndex class with the same
+        # parameters as the current class, but with the inv_order = 1
+        si = SimilarityIndex(
+            method=self.method,
+            inv_order=1,
+            similarity_index=self.similarity_index,
+            c_threshold=self.c_threshold,
+            w_factor=self.w_factor,
+        )
+
         # for each sample calculate the similarity index of the complete set without the sample
         for idx, obj in enumerate(comp_sums):
             # calculate the similarity index of the set of objects without the current object
-            sim_index = self(arr=obj, n_objects=n_objects - 1)
+            sim_index = si(arr=obj, n_objects=n_objects - 1)
             # if the similarity is bigger than the previous minimum similarity, update the minimum
             # similarity and the index
             if sim_index > max_sim:

--- a/selector/methods/similarity.py
+++ b/selector/methods/similarity.py
@@ -419,11 +419,13 @@ class SimilarityIndex:
     -------
     calculate_medoid(arr, c_total=None):
         Calculate the medoid of a set of real-valued vectors or binary objects. The similarity_index
-        is used as the distance.
+        is used as the distance. The similarity_index used for calculating the medoid always has
+        p-norm = 1.
 
     calculate_outlier(arr, c_total=None):
         Calculate the outlier of a set of real-valued vectors or binary objects. The
-        similarity_index is used as the distance.
+        similarity_index is used as the distance. The similarity_index used for calculating the
+        outlier always has p-norm = 1.
 
     __call__(arr=None, n_objects=None):
         Calculate the similarity index of a set of vectors.
@@ -455,9 +457,10 @@ class SimilarityIndex:
                     method requires the use of weight factors and coincidence thresholds.
             Default is "isim".
 
-        k : int, optional
-            Integer indicating the 1/k power used to approximate the average of the
-            similarity values elevated to 1/k. Default is 1.
+        inv_order : int, optional
+            Integer indicating the 1/inv_order power used to approximate the average of the
+            similarity values elevated to 1/inv_order. This is not used for calculating the
+            medoid or the outlier. Default is 1.
 
         similarity_index : str, optional
             The key with the abbreviation of the similarity index to be used for calculations.

--- a/selector/methods/similarity.py
+++ b/selector/methods/similarity.py
@@ -119,6 +119,7 @@ class NSimilarity(SelectionBase):
                 'power_n' : similarity = n**-(n_objects - d[k])
                             dissimilarity = n**-(d[k] - n_objects % 2)
                 other values : similarity = dissimilarity = 1
+            Only used for the 'esim' method. Default is 'fraction'.
         c_threshold: {None, 'dissimilar', int}
             Coincidence threshold used for calculating the similarity counters. A column of the
             elements is considered to be a coincidence among the elements if the number of elements
@@ -126,6 +127,7 @@ class NSimilarity(SelectionBase):
                 None : Default, c_threshold = n_objects % 2
                 'dissimilar' : c_threshold = ceil(n_objects / 2)
                 int : Integer number < n_objects
+            Only used for the 'esim' method. Default is None.
         preprocess_data: bool
             Every data element must be between 0 and 1 for the similarity indexes to work. If
             preprocess_data is True, the data is scaled between 0 and 1 using a strategy that is
@@ -482,6 +484,7 @@ class SimilarityIndex:
                 - None : Default, c_threshold = n_objects % 2
                 - 'dissimilar' : c_threshold = ceil(n_objects / 2)
                 - int : Integer number < n_objects
+            It is only used for the 'esim' method. Default is None.
 
         w_factor : {"fraction", "power_n"}, optional
             The type of weight function to be used.
@@ -493,6 +496,7 @@ class SimilarityIndex:
                 similarity = dissimilarity = 1
             Default is 'fraction'.
                 other values : similarity = dissimilarity = 1
+            It is only used for the 'esim' method. Default is 'fraction'.
         """
         # check if the method is valid
         if method not in ["isim", "esim"]:

--- a/selector/tests/data/ref_esim_selection_data.csv
+++ b/selector/tests/data/ref_esim_selection_data.csv
@@ -1,4 +1,4 @@
-c_threshold,w_factor,sample_size,start_idx,n_ary,result
+c_threshold;w_factor;sample_size;start_idx;n_ary;result
 None;fraction;10;medoid;AC;[96,33,0,49,1,66,3,35,8,37]
 None;fraction;10;outlier;AC;[4,42,8,17,5,19,10,22,13,49]
 None;fraction;10;[1,2,3];AC;[1,2,3,16,0,64,6,85,4,12]

--- a/selector/tests/test_similarity.py
+++ b/selector/tests/test_similarity.py
@@ -417,7 +417,7 @@ def _get_binary_data():
     return data
 
 
-def _get_ref_similarity_dict():
+def _get_ref_similarity_esim_dict():
     """Returns a dictionary with the reference values for the similarity indexes.
 
     The proper results for the tests are known in advance and are stored in a dictionary.
@@ -550,6 +550,119 @@ def _get_ref_similarity_dict():
 
     return ref_similarity_binary
 
+def _get_ref_isim_dict():
+    """Returns a dictionary with the reference values necessary for testing the isim method.
+
+    The proper results for the tests are known in advance and are stored in a dictionary.
+
+    Returns
+    -------
+    dict
+        A dictionary with the reference values necessary for all the isim method tests. The
+        dictionary has the following structure:
+            {n_ary: { outlier: value, medoid: value, kval2si: {k: value}}} where:
+                n_ary: the similarity index name used
+                outlier: the index of the outlier sample
+                medoid: the index of the medoid sample
+                kval2si: a dictionary with the k value as key and the similarity index as value
+    """
+    isim_dict={'AC': {'outlier': 49,
+        'medoid': 96,
+        'kval2si': {1: 0.49917475122243926,
+        2: 0.5538883964836272,
+        5: 0.5866150284585204,
+        10: 0.5974286117693461}},
+        'BUB': {'outlier': 85,
+        'medoid': 10,
+        'kval2si': {1: 0.49397989672931264,
+        2: 0.5819613020487422,
+        5: 0.6335183244648649,
+        10: 0.6502407823406905}},
+        'CT1': {'outlier': 49,
+        'medoid': 96,
+        'kval2si': {1: 0.9367065121244419,
+        2: 0.9261583241959612,
+        5: 0.9107923779571723,
+        10: 0.902405671341302}},
+        'CT2': {'outlier': 49,
+        'medoid': 96,
+        'kval2si': {1: 0.06282178200501828,
+        2: 0.12056333324739296,
+        5: 0.19665579893673796,
+        10: 0.23722036836219337}},
+        'CT3': {'outlier': 85,
+        'medoid': 10,
+        'kval2si': {1: 0.870243523865252,
+        2: 0.82843367496858,
+        5: 0.77434619420322,
+        10: 0.7461466827474635}},
+        'CT4': {'outlier': 85,
+        'medoid': 10,
+        'kval2si': {1: 0.8945856132657759,
+        2: 0.8706848775823933,
+        5: 0.8375702929632953,
+        10: 0.8197597232141359}},
+        'Fai': {'outlier': 85,
+        'medoid': 10,
+        'kval2si': {1: 0.36944444444444446,
+        2: 0.4354778372150966,
+        5: 0.47461264224551747,
+        10: 0.4873954166765502}},
+        'Gle': {'outlier': 85,
+        'medoid': 10,
+        'kval2si': {1: 0.48934163365402755,
+        2: 0.579696056605444,
+        5: 0.6326571892686095,
+        10: 0.6498200476852635}},
+        'Ja': {'outlier': 85,
+        'medoid': 10,
+        'kval2si': {1: 0.5897241588360109,
+        2: 0.6741446014011255,
+        5: 0.7209338061721255,
+        10: 0.735695295519683}},
+        'Ja0': {'outlier': 49,
+        'medoid': 96,
+        'kval2si': {1: 0.7490265158538847,
+        2: 0.8082737370566611,
+        5: 0.8388469288245588,
+        10: 0.8482013298830383}},
+        'JT': {'outlier': 85,
+        'medoid': 10,
+        'kval2si': {1: 0.3239260739260739,
+        2: 0.4081492974102138,
+        5: 0.4626909830536219,
+        10: 0.48128402926677866}},
+        'RT': {'outlier': 49,
+        'medoid': 96,
+        'kval2si': {1: 0.3321820648822006,
+        2: 0.41267273273100585,
+        5: 0.4645381672067039,
+        10: 0.48220837765022756}},
+        'RR': {'outlier': 85,
+        'medoid': 10,
+        'kval2si': {1: 0.2401851851851852,
+        2: 0.2867117470582547,
+        5: 0.3148435010613659,
+        10: 0.3241287740619748}},
+        'SM': {'outlier': 49,
+        'medoid': 96,
+        'kval2si': {1: 0.4987037037037037,
+        2: 0.5842439273719385,
+        5: 0.6343817834296691,
+        10: 0.6506620592911254}},
+        'SS1': {'outlier': 85,
+        'medoid': 10,
+        'kval2si': {1: 0.19326478915213827,
+        2: 0.25639923187909175,
+        5: 0.3009746107992553,
+        10: 0.3169019346220607}},
+        'SS2': {'outlier': 49,
+        'medoid': 96,
+        'kval2si': {1: 0.6655134066477203,
+        2: 0.7375681450029299,
+        5: 0.7762957099270287,
+        10: 0.7883649540846069}}}
+    return isim_dict
 
 def _get_absolute_decimal_places_for_comparison(num1, num2, rtol=1e-4):
     """Calculate the absolute number of decimal places needed for comparison of two numbers.
@@ -605,7 +718,7 @@ n_ary_values = [
 @pytest.mark.parametrize("c_threshold", c_treshold_values)
 @pytest.mark.parametrize("w_factor", w_factor_values)
 @pytest.mark.parametrize("n_ary", n_ary_values)
-def test_SimilarityIndex_call(c_threshold, w_factor, n_ary):
+def test_SimilarityIndex_esim_call(c_threshold, w_factor, n_ary):
     """Test the similarity index for binary data.
 
     Test the similarity index for binary data using the reference values and several combinations
@@ -622,7 +735,7 @@ def test_SimilarityIndex_call(c_threshold, w_factor, n_ary):
     """
 
     # get the binary data
-    data, ref_similarity_binary = _get_binary_data(), _get_ref_similarity_dict()
+    data, ref_similarity_binary = _get_binary_data(), _get_ref_similarity_esim_dict()
 
     # create instance of the class SimilarityIndex to test the similarity indexes for binary data
     sim_idx = SimilarityIndex(
@@ -693,7 +806,7 @@ def _get_esim_test_parameters():
                 c_key = "None"
             for n in n_ary_values:
                 # ignore the cases where the similarity of the samples less than two percent
-                if not _get_ref_similarity_dict()[w][c_key][n] < 0.02:
+                if not _get_ref_similarity_esim_dict()[w][c_key][n] < 0.02:
                     test_parameters.append((c, w, n))
 
     return test_parameters

--- a/selector/tests/test_similarity.py
+++ b/selector/tests/test_similarity.py
@@ -1185,6 +1185,19 @@ def test_calculate_outlier_esim(c_threshold, w_factor, n_ary):
     # check that the calculated outlier is equal to the reference outlier
     assert_equal(outlier, ref_outlier)
 
+# --------------------------------------------------------------------------------------------- #
+# Section of the tests for selection of indexes functions using binary data and isim method.
+# --------------------------------------------------------------------------------------------- #
+# test medoid selection
+@pytest.mark.parametrize("sim_idx",["AC", "BUB", "CT1", "CT2", "CT3", "CT4", "Fai", "Gle", "Ja", "Ja0", "JT", "RT", "RR", "SM", "SS1", "SS2"])
+def test_calculate_medoid_isim(sim_idx):
+    data=_get_binary_data()
+    isim_dict=_get_ref_isim_dict()
+    ref_medoid=isim_dict[sim_idx]['medoid']
+    sim_idx = SimilarityIndex(method="isim", similarity_index=sim_idx)
+    medoid = sim_idx.calculate_medoid(arr=data)
+    assert_equal(medoid, ref_medoid)
+
 
 # --------------------------------------------------------------------------------------------- #
 # Section of the test for the NSimilarity class using binary data and esim method.
@@ -1482,3 +1495,5 @@ def test_NSimilarity_esim_select(c_threshold, w_factor, sample_size, n_ary, star
 
     # check if the selected data is equal to the reference data
     assert all(x in ref_list for x in selected_data)
+
+

--- a/selector/tests/test_similarity.py
+++ b/selector/tests/test_similarity.py
@@ -550,6 +550,7 @@ def _get_ref_similarity_esim_dict():
 
     return ref_similarity_binary
 
+
 def _get_ref_isim_dict():
     """Returns a dictionary with the reference values necessary for testing the isim method.
 
@@ -566,103 +567,170 @@ def _get_ref_isim_dict():
                 medoid: the index of the medoid sample
                 kval2si: a dictionary with the k value as key and the similarity index as value
     """
-    isim_dict={'AC': {'outlier': 49,
-        'medoid': 96,
-        'kval2si': {1: 0.49917475122243926,
-        2: 0.5538883964836272,
-        5: 0.5866150284585204,
-        10: 0.5974286117693461}},
-        'BUB': {'outlier': 85,
-        'medoid': 10,
-        'kval2si': {1: 0.49397989672931264,
-        2: 0.5819613020487422,
-        5: 0.6335183244648649,
-        10: 0.6502407823406905}},
-        'CT1': {'outlier': 49,
-        'medoid': 96,
-        'kval2si': {1: 0.9367065121244419,
-        2: 0.9261583241959612,
-        5: 0.9107923779571723,
-        10: 0.902405671341302}},
-        'CT2': {'outlier': 49,
-        'medoid': 96,
-        'kval2si': {1: 0.06282178200501828,
-        2: 0.12056333324739296,
-        5: 0.19665579893673796,
-        10: 0.23722036836219337}},
-        'CT3': {'outlier': 85,
-        'medoid': 10,
-        'kval2si': {1: 0.870243523865252,
-        2: 0.82843367496858,
-        5: 0.77434619420322,
-        10: 0.7461466827474635}},
-        'CT4': {'outlier': 85,
-        'medoid': 10,
-        'kval2si': {1: 0.8945856132657759,
-        2: 0.8706848775823933,
-        5: 0.8375702929632953,
-        10: 0.8197597232141359}},
-        'Fai': {'outlier': 85,
-        'medoid': 10,
-        'kval2si': {1: 0.36944444444444446,
-        2: 0.4354778372150966,
-        5: 0.47461264224551747,
-        10: 0.4873954166765502}},
-        'Gle': {'outlier': 85,
-        'medoid': 10,
-        'kval2si': {1: 0.48934163365402755,
-        2: 0.579696056605444,
-        5: 0.6326571892686095,
-        10: 0.6498200476852635}},
-        'Ja': {'outlier': 85,
-        'medoid': 10,
-        'kval2si': {1: 0.5897241588360109,
-        2: 0.6741446014011255,
-        5: 0.7209338061721255,
-        10: 0.735695295519683}},
-        'Ja0': {'outlier': 49,
-        'medoid': 96,
-        'kval2si': {1: 0.7490265158538847,
-        2: 0.8082737370566611,
-        5: 0.8388469288245588,
-        10: 0.8482013298830383}},
-        'JT': {'outlier': 85,
-        'medoid': 10,
-        'kval2si': {1: 0.3239260739260739,
-        2: 0.4081492974102138,
-        5: 0.4626909830536219,
-        10: 0.48128402926677866}},
-        'RT': {'outlier': 49,
-        'medoid': 96,
-        'kval2si': {1: 0.3321820648822006,
-        2: 0.41267273273100585,
-        5: 0.4645381672067039,
-        10: 0.48220837765022756}},
-        'RR': {'outlier': 85,
-        'medoid': 10,
-        'kval2si': {1: 0.2401851851851852,
-        2: 0.2867117470582547,
-        5: 0.3148435010613659,
-        10: 0.3241287740619748}},
-        'SM': {'outlier': 49,
-        'medoid': 96,
-        'kval2si': {1: 0.4987037037037037,
-        2: 0.5842439273719385,
-        5: 0.6343817834296691,
-        10: 0.6506620592911254}},
-        'SS1': {'outlier': 85,
-        'medoid': 10,
-        'kval2si': {1: 0.19326478915213827,
-        2: 0.25639923187909175,
-        5: 0.3009746107992553,
-        10: 0.3169019346220607}},
-        'SS2': {'outlier': 49,
-        'medoid': 96,
-        'kval2si': {1: 0.6655134066477203,
-        2: 0.7375681450029299,
-        5: 0.7762957099270287,
-        10: 0.7883649540846069}}}
+    isim_dict = {
+        "AC": {
+            "outlier": 49,
+            "medoid": 96,
+            "kval2si": {
+                1: 0.49917475122243926,
+                2: 0.5538883964836272,
+                5: 0.5866150284585204,
+                10: 0.5974286117693461,
+            },
+        },
+        "BUB": {
+            "outlier": 85,
+            "medoid": 10,
+            "kval2si": {
+                1: 0.49397989672931264,
+                2: 0.5819613020487422,
+                5: 0.6335183244648649,
+                10: 0.6502407823406905,
+            },
+        },
+        "CT1": {
+            "outlier": 49,
+            "medoid": 96,
+            "kval2si": {
+                1: 0.9367065121244419,
+                2: 0.9261583241959612,
+                5: 0.9107923779571723,
+                10: 0.902405671341302,
+            },
+        },
+        "CT2": {
+            "outlier": 49,
+            "medoid": 96,
+            "kval2si": {
+                1: 0.06282178200501828,
+                2: 0.12056333324739296,
+                5: 0.19665579893673796,
+                10: 0.23722036836219337,
+            },
+        },
+        "CT3": {
+            "outlier": 85,
+            "medoid": 10,
+            "kval2si": {
+                1: 0.870243523865252,
+                2: 0.82843367496858,
+                5: 0.77434619420322,
+                10: 0.7461466827474635,
+            },
+        },
+        "CT4": {
+            "outlier": 85,
+            "medoid": 10,
+            "kval2si": {
+                1: 0.8945856132657759,
+                2: 0.8706848775823933,
+                5: 0.8375702929632953,
+                10: 0.8197597232141359,
+            },
+        },
+        "Fai": {
+            "outlier": 85,
+            "medoid": 10,
+            "kval2si": {
+                1: 0.36944444444444446,
+                2: 0.4354778372150966,
+                5: 0.47461264224551747,
+                10: 0.4873954166765502,
+            },
+        },
+        "Gle": {
+            "outlier": 85,
+            "medoid": 10,
+            "kval2si": {
+                1: 0.48934163365402755,
+                2: 0.579696056605444,
+                5: 0.6326571892686095,
+                10: 0.6498200476852635,
+            },
+        },
+        "Ja": {
+            "outlier": 85,
+            "medoid": 10,
+            "kval2si": {
+                1: 0.5897241588360109,
+                2: 0.6741446014011255,
+                5: 0.7209338061721255,
+                10: 0.735695295519683,
+            },
+        },
+        "Ja0": {
+            "outlier": 49,
+            "medoid": 96,
+            "kval2si": {
+                1: 0.7490265158538847,
+                2: 0.8082737370566611,
+                5: 0.8388469288245588,
+                10: 0.8482013298830383,
+            },
+        },
+        "JT": {
+            "outlier": 85,
+            "medoid": 10,
+            "kval2si": {
+                1: 0.3239260739260739,
+                2: 0.4081492974102138,
+                5: 0.4626909830536219,
+                10: 0.48128402926677866,
+            },
+        },
+        "RT": {
+            "outlier": 49,
+            "medoid": 96,
+            "kval2si": {
+                1: 0.3321820648822006,
+                2: 0.41267273273100585,
+                5: 0.4645381672067039,
+                10: 0.48220837765022756,
+            },
+        },
+        "RR": {
+            "outlier": 85,
+            "medoid": 10,
+            "kval2si": {
+                1: 0.2401851851851852,
+                2: 0.2867117470582547,
+                5: 0.3148435010613659,
+                10: 0.3241287740619748,
+            },
+        },
+        "SM": {
+            "outlier": 49,
+            "medoid": 96,
+            "kval2si": {
+                1: 0.4987037037037037,
+                2: 0.5842439273719385,
+                5: 0.6343817834296691,
+                10: 0.6506620592911254,
+            },
+        },
+        "SS1": {
+            "outlier": 85,
+            "medoid": 10,
+            "kval2si": {
+                1: 0.19326478915213827,
+                2: 0.25639923187909175,
+                5: 0.3009746107992553,
+                10: 0.3169019346220607,
+            },
+        },
+        "SS2": {
+            "outlier": 49,
+            "medoid": 96,
+            "kval2si": {
+                1: 0.6655134066477203,
+                2: 0.7375681450029299,
+                5: 0.7762957099270287,
+                10: 0.7883649540846069,
+            },
+        },
+    }
     return isim_dict
+
 
 def _get_absolute_decimal_places_for_comparison(num1, num2, rtol=1e-4):
     """Calculate the absolute number of decimal places needed for comparison of two numbers.
@@ -1185,27 +1253,47 @@ def test_calculate_outlier_esim(c_threshold, w_factor, n_ary):
     # check that the calculated outlier is equal to the reference outlier
     assert_equal(outlier, ref_outlier)
 
+
 # --------------------------------------------------------------------------------------------- #
 # Section of the tests for selection of indexes functions using binary data and isim method.
 # --------------------------------------------------------------------------------------------- #
 # test medoid selection
-si_idcs = ["AC", "BUB", "CT1", "CT2", "CT3", "CT4", "Fai", "Gle", "Ja", "Ja0", "JT", "RT", "RR", "SM", "SS1", "SS2"]
+si_idcs = [
+    "AC",
+    "BUB",
+    "CT1",
+    "CT2",
+    "CT3",
+    "CT4",
+    "Fai",
+    "Gle",
+    "Ja",
+    "Ja0",
+    "JT",
+    "RT",
+    "RR",
+    "SM",
+    "SS1",
+    "SS2",
+]
 
-@pytest.mark.parametrize("sim_idx",si_idcs)
+
+@pytest.mark.parametrize("sim_idx", si_idcs)
 def test_calculate_medoid_isim(sim_idx):
-    data=_get_binary_data()
-    isim_dict=_get_ref_isim_dict()
-    ref_medoid=isim_dict[sim_idx]['medoid']
+    data = _get_binary_data()
+    isim_dict = _get_ref_isim_dict()
+    ref_medoid = isim_dict[sim_idx]["medoid"]
     sim_idx = SimilarityIndex(method="isim", similarity_index=sim_idx)
     medoid = sim_idx.calculate_medoid(arr=data)
     assert_equal(medoid, ref_medoid)
 
+
 # test outlier selection
-@pytest.mark.parametrize("sim_idx",si_idcs)
+@pytest.mark.parametrize("sim_idx", si_idcs)
 def test_calculate_outlier_isim(sim_idx):
-    data=_get_binary_data()
-    isim_dict=_get_ref_isim_dict()
-    ref_medoid=isim_dict[sim_idx]['outlier']
+    data = _get_binary_data()
+    isim_dict = _get_ref_isim_dict()
+    ref_medoid = isim_dict[sim_idx]["outlier"]
     sim_idx = SimilarityIndex(method="isim", similarity_index=sim_idx)
     medoid = sim_idx.calculate_outlier(arr=data)
     assert_equal(medoid, ref_medoid)
@@ -1507,5 +1595,3 @@ def test_NSimilarity_esim_select(c_threshold, w_factor, sample_size, n_ary, star
 
     # check if the selected data is equal to the reference data
     assert all(x in ref_list for x in selected_data)
-
-

--- a/selector/tests/test_similarity.py
+++ b/selector/tests/test_similarity.py
@@ -116,17 +116,17 @@ def test_SimilarityIndex_init_raises():
     """Test the SimilarityIndex class for raised errors (initialization)."""
     # check raised error wrong similarity index name
     with pytest.raises(ValueError):
-        SimilarityIndex(similarity_index="ttt")
+        SimilarityIndex(method="esim", similarity_index="ttt")
     # check raised error wrong c_threshold - invalid string value
     with pytest.raises(ValueError):
-        SimilarityIndex(c_threshold="ttt")
+        SimilarityIndex(method="esim", c_threshold="ttt")
     # check raised error wrong c_threshold - invalid type (not int)
     with pytest.raises(ValueError):
-        SimilarityIndex(c_threshold=1.1)
+        SimilarityIndex(method="esim", c_threshold=1.1)
 
 
 def test_SimilarityIndex_calculate_counters_raises():
-    sim_idx = SimilarityIndex()
+    sim_idx = SimilarityIndex(method="esim")
 
     # check raised error wrong data type
     with pytest.raises(TypeError):
@@ -137,18 +137,18 @@ def test_SimilarityIndex_calculate_counters_raises():
         sim_idx._calculate_counters(arr=np.array([1, 2, 3]))
 
     # check raised error - c_threshold bigger than n_objects
-    sim_idx = SimilarityIndex(c_threshold=3)
+    sim_idx = SimilarityIndex(method="esim", c_threshold=3)
     with pytest.raises(ValueError):
         sim_idx._calculate_counters(arr=np.array([[1, 2, 3], [4, 5, 6]]))
 
     # check raised error - invalid c_threshold string value
-    sim_idx = SimilarityIndex()
+    sim_idx = SimilarityIndex(method="esim")
     sim_idx.c_threshold = "ttt"
     with pytest.raises(ValueError):
         sim_idx._calculate_counters(arr=np.array([[1, 2, 3], [4, 5, 6]]))
 
     # check raised error - invalid weight factor string value
-    sim_idx = SimilarityIndex()
+    sim_idx = SimilarityIndex(method="esim")
     sim_idx.w_factor = "ttt"
     with pytest.raises(ValueError):
         sim_idx._calculate_counters(arr=np.array([[1, 2, 3], [4, 5, 6]]))
@@ -182,7 +182,7 @@ def test_SimilarityIndex_calculate_medoid_raises():
         sim_idx.calculate_medoid(arr=np.array([[1, 2, 3], [4, 5, 6]]))
 
     # check raised error - c_threshold bigger than n_objects
-    sim_idx = SimilarityIndex(c_threshold=4)
+    sim_idx = SimilarityIndex(method="esim", c_threshold=4)
     with pytest.raises(ValueError):
         sim_idx.calculate_medoid(arr=np.array([[1, 2, 3], [4, 5, 6], [6, 7, 8]]))
 
@@ -211,7 +211,7 @@ def test_SimilarityIndex_calculate_outlier_raises():
         sim_idx.calculate_outlier(arr=np.array([[1, 2, 3], [4, 5, 6]]))
 
     # check raised error - c_threshold bigger than n_objects
-    sim_idx = SimilarityIndex(c_threshold=4)
+    sim_idx = SimilarityIndex(method="esim", c_threshold=4)
     with pytest.raises(ValueError):
         sim_idx.calculate_outlier(arr=np.array([[1, 2, 3], [4, 5, 6], [6, 7, 8]]))
 
@@ -230,14 +230,15 @@ def test_NSimilarity_init_raises():
         NSimilarity(similarity_index="ttt")
     # check raised error wrong c_threshold - invalid string value
     with pytest.raises(ValueError):
-        NSimilarity(c_threshold="ttt")
+        NSimilarity(method="esim", c_threshold="ttt")
     # check raised error wrong c_threshold - invalid type (not int)
     with pytest.raises(ValueError):
-        NSimilarity(c_threshold=1.1)
+        NSimilarity(method="esim", c_threshold=1.1)
 
 
 def test_NSimilarity_get_new_index_raises():
     """Test the NSimilarity class for raised errors (get_new_index)."""
+    # check that data is not scaled between 0 and 1
     with pytest.raises(ValueError):
         NSimilarity()._get_new_index(
             arr=np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
@@ -291,7 +292,7 @@ def test_NSimilarity_select_from_cluster_raises():
 # --------------------------------------------------------------------------------------------- #
 
 # --------------------------------------------------------------------------------------------- #
-# Section of the test for the SimilarityIndex class
+# Section of the test for the SimilarityIndex class using binary data and esim method.
 # --------------------------------------------------------------------------------------------- #
 
 
@@ -624,7 +625,9 @@ def test_SimilarityIndex_call(c_threshold, w_factor, n_ary):
     data, ref_similarity_binary = _get_binary_data(), _get_ref_similarity_dict()
 
     # create instance of the class SimilarityIndex to test the similarity indexes for binary data
-    sim_idx = SimilarityIndex(similarity_index=n_ary, c_threshold=c_threshold, w_factor=w_factor)
+    sim_idx = SimilarityIndex(
+        method="esim", similarity_index=n_ary, c_threshold=c_threshold, w_factor=w_factor
+    )
 
     # calculate the similarity index for the binary data
     sim_idx_value = sim_idx(data)
@@ -642,7 +645,7 @@ def test_SimilarityIndex_call(c_threshold, w_factor, n_ary):
 
 
 # --------------------------------------------------------------------------------------------- #
-# Section of the tests for selection of indexes functions
+# Section of the tests for selection of indexes functions using binary data and esim method.
 # --------------------------------------------------------------------------------------------- #
 
 # Many of the combinations of parameters for the tests are too stringent and the similarity of the
@@ -875,7 +878,9 @@ def test_calculate_medoid(c_threshold, w_factor, n_ary):
     ref_medoid = ref_medoid_dict[c_threshold_key][w_factor][n_ary]
 
     # calculate the medoid for the binary data
-    sim_idx = SimilarityIndex(similarity_index=n_ary, c_threshold=c_threshold, w_factor=w_factor)
+    sim_idx = SimilarityIndex(
+        method="esim", similarity_index=n_ary, c_threshold=c_threshold, w_factor=w_factor
+    )
     medoid = sim_idx.calculate_medoid(arr=data)
 
     # check that the calculated medoid is equal to the reference medoid
@@ -1059,7 +1064,9 @@ def test_calculate_outlier(c_threshold, w_factor, n_ary):
     ref_outlier = ref_outlier_dict[c_threshold_key][w_factor][n_ary]
 
     # calculate the outlier for the binary data
-    sim_idx = SimilarityIndex(similarity_index=n_ary, c_threshold=c_threshold, w_factor=w_factor)
+    sim_idx = SimilarityIndex(
+        method="esim", similarity_index=n_ary, c_threshold=c_threshold, w_factor=w_factor
+    )
     outlier = sim_idx.calculate_outlier(arr=data)
 
     # check that the calculated outlier is equal to the reference outlier
@@ -1221,7 +1228,9 @@ def test_get_new_index(c_threshold, w_factor, n_ary):
     ref_new_index = ref_new_index_dict[c_threshold_key][w_factor][n_ary]
 
     # calculate the outlier for the binary data
-    nsi = NSimilarity(similarity_index=n_ary, w_factor=w_factor, c_threshold=c_threshold)
+    nsi = NSimilarity(
+        method="esim", similarity_index=n_ary, w_factor=w_factor, c_threshold=c_threshold
+    )
 
     new_index = nsi._get_new_index(
         arr=data,
@@ -1338,6 +1347,7 @@ def test_NSimilarity_select(c_threshold, w_factor, sample_size, n_ary, start):
 
     # create instance of the class SimilarityIndex to test the similarity indexes for binary data
     selector = NSimilarity(
+        method="esim",
         similarity_index=n_ary,
         w_factor=w_factor,
         c_threshold=c_threshold,

--- a/selector/tests/test_similarity.py
+++ b/selector/tests/test_similarity.py
@@ -1189,13 +1189,25 @@ def test_calculate_outlier_esim(c_threshold, w_factor, n_ary):
 # Section of the tests for selection of indexes functions using binary data and isim method.
 # --------------------------------------------------------------------------------------------- #
 # test medoid selection
-@pytest.mark.parametrize("sim_idx",["AC", "BUB", "CT1", "CT2", "CT3", "CT4", "Fai", "Gle", "Ja", "Ja0", "JT", "RT", "RR", "SM", "SS1", "SS2"])
+si_idcs = ["AC", "BUB", "CT1", "CT2", "CT3", "CT4", "Fai", "Gle", "Ja", "Ja0", "JT", "RT", "RR", "SM", "SS1", "SS2"]
+
+@pytest.mark.parametrize("sim_idx",si_idcs)
 def test_calculate_medoid_isim(sim_idx):
     data=_get_binary_data()
     isim_dict=_get_ref_isim_dict()
     ref_medoid=isim_dict[sim_idx]['medoid']
     sim_idx = SimilarityIndex(method="isim", similarity_index=sim_idx)
     medoid = sim_idx.calculate_medoid(arr=data)
+    assert_equal(medoid, ref_medoid)
+
+# test outlier selection
+@pytest.mark.parametrize("sim_idx",si_idcs)
+def test_calculate_outlier_isim(sim_idx):
+    data=_get_binary_data()
+    isim_dict=_get_ref_isim_dict()
+    ref_medoid=isim_dict[sim_idx]['outlier']
+    sim_idx = SimilarityIndex(method="isim", similarity_index=sim_idx)
+    medoid = sim_idx.calculate_outlier(arr=data)
     assert_equal(medoid, ref_medoid)
 
 

--- a/selector/tests/test_similarity.py
+++ b/selector/tests/test_similarity.py
@@ -663,7 +663,7 @@ def test_SimilarityIndex_call(c_threshold, w_factor, n_ary):
 # The cases where the similarity of the samples is zero are not considered because these will be
 # inconsistent with the reference values for the selection of the new indexes, and the calculation
 # of the medoid and the outlier.
-def _get_test_parameters():
+def _get_esim_test_parameters():
     """Returns the parameters for the tests.
 
     Returns the parameters for the tests. The parameters are stored in a list of tuples. Each tuple
@@ -699,11 +699,11 @@ def _get_test_parameters():
     return test_parameters
 
 
-parameters = _get_test_parameters()
+parameters = _get_esim_test_parameters()
 
 
-def _get_ref_medoid_dict():
-    """Returns a dictionary with the reference values for the medoid.
+def _get_ref_medoid_esim_dict():
+    """Returns dictionary with reference medoid index for binary data using esim method.
 
     The proper results for the tests are known in advance and are stored in a dictionary.
 
@@ -848,8 +848,8 @@ def _get_ref_medoid_dict():
 
 
 @pytest.mark.parametrize("c_threshold, w_factor, n_ary", parameters)
-def test_calculate_medoid(c_threshold, w_factor, n_ary):
-    """Test the function to calculate the medoid for binary data.
+def test_calculate_medoid_esim(c_threshold, w_factor, n_ary):
+    """Test the function to calculate the medoid for binary data using esim method.
 
     Test the function to calculate the medoid for binary data using the reference values and several
     combinations of parameters. The reference values are obtained using the function
@@ -868,7 +868,7 @@ def test_calculate_medoid(c_threshold, w_factor, n_ary):
     # get the reference binary data
     data = _get_binary_data()
     # get the reference value for the medoid
-    ref_medoid_dict = _get_ref_medoid_dict()
+    ref_medoid_dict = _get_ref_medoid_esim_dict()
 
     # small hack to avoid using the None value as a key in the dictionary
     c_threshold_key = c_threshold
@@ -888,12 +888,12 @@ def test_calculate_medoid(c_threshold, w_factor, n_ary):
 
 
 # results from the reference code
-def _get_ref_outlier_dict():
-    """Returns a dictionary with the reference values for the outlier.
+def _get_ref_outlier_esim_dict():
+    """Returns dictionary with reference outlier index for binary data using esim method.
 
     The proper results for the tests are known in advance and are stored in a dictionary.
 
-    The dictionary has the following structure:
+        The dictionary has the following structure:
         {w_factor: {c_threshold: {n_ary: value}}} where:
             w_factor: the weight factor for the similarity index
             c_threshold: the threshold value for the similarity index
@@ -1034,8 +1034,8 @@ def _get_ref_outlier_dict():
 
 
 @pytest.mark.parametrize("c_threshold, w_factor, n_ary", parameters)
-def test_calculate_outlier(c_threshold, w_factor, n_ary):
-    """Test the function to calculate the outlier for binary data.
+def test_calculate_outlier_esim(c_threshold, w_factor, n_ary):
+    """Test the function to calculate the outlier for binary data using the esim method.
 
     Test the function to calculate the outlier for binary data using the reference values and
     several combinations of parameters. The reference values are obtained using the function
@@ -1054,7 +1054,7 @@ def test_calculate_outlier(c_threshold, w_factor, n_ary):
     # get the reference binary data
     data = _get_binary_data()
     # get the reference value for the outlier
-    ref_outlier_dict = _get_ref_outlier_dict()
+    ref_outlier_dict = _get_ref_outlier_esim_dict()
 
     # small hack to avoid using the None value as a key in the dictionary
     c_threshold_key = c_threshold
@@ -1074,13 +1074,11 @@ def test_calculate_outlier(c_threshold, w_factor, n_ary):
 
 
 # --------------------------------------------------------------------------------------------- #
-# Section of the test for the NSimilarity class
+# Section of the test for the NSimilarity class using binary data and esim method.
 # --------------------------------------------------------------------------------------------- #
-
-
-def _get_ref_new_index():
+def _get_ref_new_index_esim():
     """
-    Returns reference data for testing the function to calculate the new index.
+    Returns reference data for testing the function to calculate the new index with the esim method.
 
     Returns the tuple (selected_points, new_indexes_dict) where selected_points is a list of
     selected samples given to the function (get_new_index) and new_indexes_dict is  a dictionary
@@ -1191,7 +1189,7 @@ def _get_ref_new_index():
 
 
 @pytest.mark.parametrize("c_threshold, w_factor, n_ary", parameters)
-def test_get_new_index(c_threshold, w_factor, n_ary):
+def test_get_new_index_esim(c_threshold, w_factor, n_ary):
     """Test the function get a new sample from the binary data.
 
     Test the function to get a new sample from the binary data using the reference values and
@@ -1211,7 +1209,7 @@ def test_get_new_index(c_threshold, w_factor, n_ary):
     # get the reference binary data
     data = _get_binary_data()
     # get the reference value for the outlier
-    selected_samples, ref_new_index_dict = _get_ref_new_index()
+    selected_samples, ref_new_index_dict = _get_ref_new_index_esim()
 
     # columnwise sum of the selected samples
     selected_condensed_data = np.sum(np.take(data, selected_samples, axis=0), axis=0)
@@ -1256,11 +1254,10 @@ start_values = ["medoid", "outlier", [1, 2, 3]]
 # sample size values to test
 sample_size_values = [10, 20, 30]
 
+
 # --------------------------------------------------------------------------------------------- #
 # Get reference data for testing the selection of the diverse subset
 # --------------------------------------------------------------------------------------------- #
-
-
 def get_data_file_path(file_name):
     """Get the absolute path of the data file inside the package.
 
@@ -1278,7 +1275,8 @@ def get_data_file_path(file_name):
     return data_file_path
 
 
-def _get_selections_ref_dict():
+# get reference selected data for esim method
+def _get_selections_esim_ref_dict():
     """Returns a dictionary with the reference values for the selection of samples.
 
     The proper results for the tests are known in advance and are stored in a csv file.
@@ -1292,7 +1290,7 @@ def _get_selections_ref_dict():
             start: the method to use to select the first(s) sample(s)
     """
 
-    file_path = get_data_file_path("ref_similarity_data.csv")
+    file_path = get_data_file_path("ref_esim_selection_data.csv")
     with open(file_path, encoding="utf-8") as file:
         reader = csv.reader(file, delimiter=";")
         next(reader)  # skip header
@@ -1315,13 +1313,11 @@ def _get_selections_ref_dict():
     return data_dict
 
 
-print(_get_selections_ref_dict())
-
-
+# test selected data for esim method (inv_order=1) and binary data against reference data
 @pytest.mark.parametrize("c_threshold, w_factor, n_ary", parameters)
 @pytest.mark.parametrize("sample_size", sample_size_values)
 @pytest.mark.parametrize("start", start_values)
-def test_NSimilarity_select(c_threshold, w_factor, sample_size, n_ary, start):
+def test_NSimilarity_esim_select(c_threshold, w_factor, sample_size, n_ary, start):
     """
     Test the diversity selection methods based on similarity indexes for binary data.
 
@@ -1343,7 +1339,7 @@ def test_NSimilarity_select(c_threshold, w_factor, sample_size, n_ary, start):
     # get the binary data
     data = _get_binary_data()
     # get the reference selected data
-    reference_selected_data = _get_selections_ref_dict()
+    reference_selected_data = _get_selections_esim_ref_dict()
 
     # create instance of the class SimilarityIndex to test the similarity indexes for binary data
     selector = NSimilarity(


### PR DESCRIPTION
This PR should close (for now) the implementation of n-ary similarity methods.

Addressed problems
-----

1. Added support to the Instant Similarity ( `isim`)
    -  Implemented support for Instant Similarity (isim) methods within the NSimilarity and SimilarityIndex classes.
    - The previous method for calculating average similarity is now called Extended Similarity ( `esim`) and is supported for "backward compatibility?" 
2. Added support for `esim` and `isim`  to utilize a p-norm average similarity.
3. Added tests for the  `isim` method with the different similarity indexes and p-norm averages using reference data generated by Ramón's group code

Remaining things to do (future)
----
1. We don't have a source of reference data for `esim` with p-norm averages different than 1.
2. Improve docstrings format 

Notes: After this is merged, the Quickstart notebook (PR #186) can showcase the new flexibility of the methods.
