### PR TITLE
Upgrade codecov-action version 4.x

### DIFF
--- a/.github/workflows/ci_codecov.yml
+++ b/.github/workflows/ci_codecov.yml
@@ -63,7 +63,7 @@ jobs:
         python -m pytest -c pyproject.toml --cov-config=.coveragerc --cov-report=xml --color=yes selector
 
     - name: CodeCov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true


### PR DESCRIPTION
This PR fixes the outdated `codecov-action` version.