### PR TITLE
[Similarity module] Scaled similarity support

### DIFF
--- a/selector/similarity.py
+++ b/selector/similarity.py
@@ -25,7 +25,12 @@ from itertools import combinations_with_replacement
 
 import numpy as np
 
-__all__ = ["pairwise_similarity_bit", "tanimoto", "modified_tanimoto", "scaled_similarity_matrix"]
+__all__ = [
+    "pairwise_similarity_bit",
+    "tanimoto",
+    "modified_tanimoto",
+    "scaled_similarity_matrix",
+]
 
 
 def pairwise_similarity_bit(X: np.array, metric: str) -> np.ndarray:
@@ -201,6 +206,7 @@ def scaled_similarity_matrix(X: np.array) -> np.ndarray:
     s : ndarray of shape (n_samples, n_samples)
         A scaled symmetric similarity matrix.
     """
+
     if X.ndim != 2:
         raise ValueError(f"Argument similarity matrix should be a 2D array, got {X.ndim}")
     if X.shape[0] != X.shape[1]:

--- a/selector/similarity.py
+++ b/selector/similarity.py
@@ -183,3 +183,39 @@ def modified_tanimoto(a: np.array, b: np.array) -> float:
     #       x = (2-p)/3 so that E(mt) = 1/3, no matter the value of p
     mt = (((2 - p) / 3) * t_1) + (((1 + p) / 3) * t_0)
     return mt
+
+
+def scaled_similarity_matrix(X: np.array) -> np.ndarray:
+    """Compute the scaled similarity matrix.
+    
+    ..math::
+    X(i,j)=\frac{X(i,j)}{\sqrt{X(i,i)X(j,j)}}
+    
+    Parameters
+    ----------
+    X : ndarray of shape (n_samples, n_samples)
+        Similarity matrix of `n_samples`. 
+        
+    Returns
+    -------
+    s : ndarray of shape (n_samples, n_samples)
+        A scaled symmetric similarity matrix.
+    """
+
+    if X.ndim != 2:
+        raise ValueError(f"Argument similarity matrix should be a 2D array, got {X.ndim}")
+    if X.shape[0] != X.shape[1]:
+        raise ValueError(f"Argument similarity matrix should be a square matrix (having same number of rows and columns), got {X.shape[0]} and {X.shape[1]}")
+    if not (np.all(X >= 0) and np.all(np.diag(X)>0)):
+        raise ValueError("All elements of similarity matrix should be greater than zero and diagonals should be non-zero")
+    
+    # make a scaled similarity matrix
+    n_samples = len(X)
+    s = np.zeros((n_samples, n_samples))
+    # calculate the square root of the diagonal elements
+    sqrt_diag = np.sqrt(np.diag(X))
+    # calculate the product of the square roots of the diagonal elements
+    product_sqrt_diag = np.outer(sqrt_diag, sqrt_diag)
+    # divide each element of the matrix by the product of the square roots of diagonal elements
+    s = X / product_sqrt_diag
+    return s

--- a/selector/similarity.py
+++ b/selector/similarity.py
@@ -25,7 +25,7 @@ from itertools import combinations_with_replacement
 
 import numpy as np
 
-__all__ = ["pairwise_similarity_bit", "tanimoto", "modified_tanimoto"]
+__all__ = ["pairwise_similarity_bit", "tanimoto", "modified_tanimoto", "scaled_similarity_matrix"]
 
 
 def pairwise_similarity_bit(X: np.array, metric: str) -> np.ndarray:

--- a/selector/similarity.py
+++ b/selector/similarity.py
@@ -25,6 +25,9 @@ from itertools import combinations_with_replacement
 
 import numpy as np
 
+import logging
+logging.basicConfig(level=logging.INFO)
+
 __all__ = ["pairwise_similarity_bit", "tanimoto", "modified_tanimoto", "scaled_similarity_matrix"]
 
 
@@ -209,13 +212,18 @@ def scaled_similarity_matrix(X: np.array) -> np.ndarray:
     if not (np.all(X >= 0) and np.all(np.diag(X)>0)):
         raise ValueError("All elements of similarity matrix should be greater than zero and diagonals should be non-zero")
     
-    # make a scaled similarity matrix
-    n_samples = len(X)
-    s = np.zeros((n_samples, n_samples))
-    # calculate the square root of the diagonal elements
-    sqrt_diag = np.sqrt(np.diag(X))
-    # calculate the product of the square roots of the diagonal elements
-    product_sqrt_diag = np.outer(sqrt_diag, sqrt_diag)
-    # divide each element of the matrix by the product of the square roots of diagonal elements
-    s = X / product_sqrt_diag
-    return s
+    # scaling does not happen if the matrix is binary similarity matrix with all diagonal elements as 1
+    if np.all(np.diag(X)==1):
+        logging.info("No scaling is taking effect")
+        return X
+    else:
+        # make a scaled similarity matrix
+        n_samples = len(X)
+        s = np.zeros((n_samples, n_samples))
+        # calculate the square root of the diagonal elements
+        sqrt_diag = np.sqrt(np.diag(X))
+        # calculate the product of the square roots of the diagonal elements
+        product_sqrt_diag = np.outer(sqrt_diag, sqrt_diag)
+        # divide each element of the matrix by the product of the square roots of diagonal elements
+        s = X / product_sqrt_diag
+        return s

--- a/selector/similarity.py
+++ b/selector/similarity.py
@@ -204,14 +204,13 @@ def scaled_similarity_matrix(X: np.array) -> np.ndarray:
     s : ndarray of shape (n_samples, n_samples)
         A scaled symmetric similarity matrix.
     """
-
     if X.ndim != 2:
         raise ValueError(f"Argument similarity matrix should be a 2D array, got {X.ndim}")
     if X.shape[0] != X.shape[1]:
         raise ValueError(f"Argument similarity matrix should be a square matrix (having same number of rows and columns), got {X.shape[0]} and {X.shape[1]}")
     if not (np.all(X >= 0) and np.all(np.diag(X)>0)):
         raise ValueError("All elements of similarity matrix should be greater than zero and diagonals should be non-zero")
-    
+
     # scaling does not happen if the matrix is binary similarity matrix with all diagonal elements as 1
     if np.all(np.diag(X)==1):
         logging.info("No scaling is taking effect")

--- a/selector/similarity.py
+++ b/selector/similarity.py
@@ -25,9 +25,6 @@ from itertools import combinations_with_replacement
 
 import numpy as np
 
-import logging
-logging.basicConfig(level=logging.INFO)
-
 __all__ = ["pairwise_similarity_bit", "tanimoto", "modified_tanimoto", "scaled_similarity_matrix"]
 
 
@@ -190,15 +187,15 @@ def modified_tanimoto(a: np.array, b: np.array) -> float:
 
 def scaled_similarity_matrix(X: np.array) -> np.ndarray:
     """Compute the scaled similarity matrix.
-    
+
     ..math::
-    X(i,j)=\frac{X(i,j)}{\sqrt{X(i,i)X(j,j)}}
-    
+    X(i,j)=\frac{X(i,j)}{\\sqrt{X(i,i)X(j,j)}}
+
     Parameters
     ----------
     X : ndarray of shape (n_samples, n_samples)
-        Similarity matrix of `n_samples`. 
-        
+        Similarity matrix of `n_samples`.
+
     Returns
     -------
     s : ndarray of shape (n_samples, n_samples)
@@ -207,13 +204,17 @@ def scaled_similarity_matrix(X: np.array) -> np.ndarray:
     if X.ndim != 2:
         raise ValueError(f"Argument similarity matrix should be a 2D array, got {X.ndim}")
     if X.shape[0] != X.shape[1]:
-        raise ValueError(f"Argument similarity matrix should be a square matrix (having same number of rows and columns), got {X.shape[0]} and {X.shape[1]}")
-    if not (np.all(X >= 0) and np.all(np.diag(X)>0)):
-        raise ValueError("All elements of similarity matrix should be greater than zero and diagonals should be non-zero")
+        raise ValueError(
+            f"Argument similarity matrix should be a square matrix (having same number of rows and columns), got {X.shape[0]} and {X.shape[1]}"
+        )
+    if not (np.all(X >= 0) and np.all(np.diag(X) > 0)):
+        raise ValueError(
+            "All elements of similarity matrix should be greater than zero and diagonals should be non-zero"
+        )
 
     # scaling does not happen if the matrix is binary similarity matrix with all diagonal elements as 1
-    if np.all(np.diag(X)==1):
-        logging.info("No scaling is taking effect")
+    if np.all(np.diag(X) == 1):
+        print("No scaling is taking effect")
         return X
     else:
         # make a scaled similarity matrix

--- a/selector/tests/test_similarity.py
+++ b/selector/tests/test_similarity.py
@@ -30,7 +30,12 @@ import pytest
 from numpy.testing import assert_almost_equal, assert_equal, assert_raises
 
 from selector.methods.similarity import NSimilarity, SimilarityIndex
-from selector.similarity import modified_tanimoto, pairwise_similarity_bit, tanimoto, scaled_similarity_matrix
+from selector.similarity import (
+    modified_tanimoto,
+    pairwise_similarity_bit,
+    scaled_similarity_matrix,
+    tanimoto,
+)
 
 
 def test_pairwise_similarity_bit_raises():

--- a/selector/tests/test_similarity.py
+++ b/selector/tests/test_similarity.py
@@ -114,9 +114,9 @@ def test_modified_tanimoto_matrix():
 
 def test_scaled_similarity_matrix():
     """Testing scaled similarity matrix function with a predefined similarity matrix."""
-    X = np.array([[1, 0.8, 0.65], [0.8, 1, 0.47], [0.65, 0.47, 1]])
+    X = np.array([[4, 2, 3], [0.5, 1, 1.5], [3, 3, 9]])
     s = scaled_similarity_matrix(X)
-    expected = np.array([[1, 0.8, 0.65], [0.8, 1, 0.47], [0.65, 0.47, 1]])
+    expected = np.array([[1, 1, 0.5], [0.25, 1, 0.5], [0.5, 1, 1]])
     assert_equal(s, expected)
 
 
@@ -124,8 +124,8 @@ def test_scaled_similarity_matrix_dimension_error():
     """Test scaled similarity matrix raises error when input has incorrect dimension."""
     X = np.array([[1, 0.8, 0.65], [0.8, 1, 0.47]])
     assert_raises(ValueError, scaled_similarity_matrix, X)
-    
-    
+
+
 def test_scaled_similarity_matrix_diagonal_zero_error():
     """Test scaled similarity matrix raises error when diagonal element is zero."""
     X = np.array([[1, 0.8, 0.65], [0.8, 0, 0.47], [0.65, 0.47, 1]])
@@ -136,8 +136,8 @@ def test_scaled_similarity_matrix_element_negative_error():
     """Test scaled similarity matrix raises error when any element is negative."""
     X = np.array([[1, 0.8, 0.65], [-0.8, 1, 0.47], [0.65, 0.47, 1]])
     assert_raises(ValueError, scaled_similarity_matrix, X)
-    
-    
+
+
 def test_SimilarityIndex_init_raises():
     """Test the SimilarityIndex class for raised errors (initialization)."""
     # check raised error wrong similarity index name

--- a/selector/tests/test_similarity.py
+++ b/selector/tests/test_similarity.py
@@ -30,7 +30,7 @@ import pytest
 from numpy.testing import assert_almost_equal, assert_equal, assert_raises
 
 from selector.methods.similarity import NSimilarity, SimilarityIndex
-from selector.similarity import modified_tanimoto, pairwise_similarity_bit, tanimoto
+from selector.similarity import modified_tanimoto, pairwise_similarity_bit, tanimoto, scaled_similarity_matrix
 
 
 def test_pairwise_similarity_bit_raises():
@@ -108,10 +108,36 @@ def test_modified_tanimoto_matrix():
     """Testing the modified tanimoto function with predefined feature matrix."""
     x = np.array([[1, 0, 1], [0, 1, 1]])
     s = pairwise_similarity_bit(x, "modified_tanimoto")
-    expceted = np.array([[1, (4 / 27)], [(4 / 27), 1]])
-    assert_equal(s, expceted)
+    expected = np.array([[1, (4 / 27)], [(4 / 27), 1]])
+    assert_equal(s, expected)
 
 
+def test_scaled_similarity_matrix():
+    """Testing scaled similarity matrix function with a predefined similarity matrix."""
+    X = np.array([[1, 0.8, 0.65], [0.8, 1, 0.47], [0.65, 0.47, 1]])
+    s = scaled_similarity_matrix(X)
+    expected = np.array([[1, 0.8, 0.65], [0.8, 1, 0.47], [0.65, 0.47, 1]])
+    assert_equal(s, expected)
+
+
+def test_scaled_similarity_matrix_dimension_error():
+    """Test scaled similarity matrix raises error when input has incorrect dimension."""
+    X = np.array([[1, 0.8, 0.65], [0.8, 1, 0.47]])
+    assert_raises(ValueError, scaled_similarity_matrix, X)
+    
+    
+def test_scaled_similarity_matrix_diagonal_zero_error():
+    """Test scaled similarity matrix raises error when diagonal element is zero."""
+    X = np.array([[1, 0.8, 0.65], [0.8, 0, 0.47], [0.65, 0.47, 1]])
+    assert_raises(ValueError, scaled_similarity_matrix, X)
+
+
+def test_scaled_similarity_matrix_element_negative_error():
+    """Test scaled similarity matrix raises error when any element is negative."""
+    X = np.array([[1, 0.8, 0.65], [-0.8, 1, 0.47], [0.65, 0.47, 1]])
+    assert_raises(ValueError, scaled_similarity_matrix, X)
+    
+    
 def test_SimilarityIndex_init_raises():
     """Test the SimilarityIndex class for raised errors (initialization)."""
     # check raised error wrong similarity index name


### PR DESCRIPTION
Adding the support of scaled similarity matrix in the similarity module by implementing the method. 

Considering $S(i,j)$ denotes the similarity between $i^{th}$ sample and $j^{th}$ sample, formula used to calculate scaled similarity matrix is
$S(i,j)={S(i,j)\over\sqrt{S(i,i)S(j,j)}}$

- Implemented the method `scaled_similarity_matrix()`
- Added the tests and docstrings

Fixes #122 
