### PR TITLE
Fix GitHub Actions crash for MacOS version change

### DIFF
--- a/.github/workflows/ci_tox.yml
+++ b/.github/workflows/ci_tox.yml
@@ -24,8 +24,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        # os: [macOS-latest, windows-latest, ubuntu-latest]
+        os: [macos-13, windows-latest, ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ numpy>=1.21.2
 pandas>=1.3.5
 pytest>=6.2.5
 scikit-learn>=1.0.1
-scipy==1.11.1
+scipy>=1.11.1
 setuptools>=58.0.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,5 +10,5 @@ pre-commit
 pytest==7.4.0
 pytest-cov>=3.0.0
 scikit-learn>=1.0.1
-scipy==1.11.1
+scipy>=1.11.1
 setuptools>=58.0.4


### PR DESCRIPTION
macos-14 aka. macos-latest has switched to being an ARM runner, only supporting newer versions of Python. This is related to https://github.com/actions/setup-python/issues/825