### PR TITLE
Add new environment token to fix the failing updating coverage report

### DIFF
--- a/.github/workflows/ci_codecov.yml
+++ b/.github/workflows/ci_codecov.yml
@@ -64,8 +64,9 @@ jobs:
 
     - name: CodeCov
       uses: codecov/codecov-action@v4
+      env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         file: ./coverage.xml
         flags: unittests


### PR DESCRIPTION
This fixes the problem of https://github.com/theochem/Selector/actions/runs/9666084225/job/26664757592.