### PR TITLE
Fix the numerical stability issue of log det function (fixes #229)

### DIFF
--- a/selector/diversity.py
+++ b/selector/diversity.py
@@ -134,13 +134,19 @@ def logdet(X: np.ndarray) -> float:
 
     Notes
     -----
-    Nakamura, T., Sakaue, S., Fujii, K., Harabuchi, Y., Maeda, S., and Iwata, S.. (2022)
-    Selecting molecules with diverse structures and properties by maximizing
-    submodular functions of descriptors learned with graph neural networks.
-    Scientific Reports 12.
+    The log-determinant function is based on the formula in [1]_. Please note that we used the
+    natural logrithim to avoid the numerical stability issues,
+    https://github.com/theochem/Selector/issues/229.
+
+    .. [1] Nakamura, T., Sakaue, S., Fujii, K., Harabuchi, Y., Maeda, S., and Iwata, S..,
+       Selecting molecules with diverse structures and properties by maximizing
+       submodular functions of descriptors learned with graph neural networks.
+       Scientific Reports 12, 2022.
+
     """
-    mid = np.dot(X, np.transpose(X))
-    f_logdet = np.log10(np.linalg.det(mid + np.identity(len(X))))
+    mid = np.dot(X, np.transpose(X)) + np.identity(X.shape[0])
+    logdet_mid = np.linalg.slogdet(mid)
+    f_logdet = logdet_mid.sign * logdet_mid.logabsdet
     return f_logdet
 
 

--- a/selector/tests/test_diversity.py
+++ b/selector/tests/test_diversity.py
@@ -105,14 +105,14 @@ def test_compute_diversity_invalid():
 def test_logdet():
     """Test the log determinant function with predefined subset matrix."""
     sel = logdet(sample3)
-    expected = np.log10(131)
+    expected = np.log(131)
     assert_almost_equal(sel, expected)
 
 
 def test_logdet_non_square_matrix():
     """Test the log determinant function with a rectangular matrix."""
     sel = logdet(sample4)
-    expected = np.log10(8)
+    expected = np.log(8)
     assert_almost_equal(sel, expected)
 
 


### PR DESCRIPTION
I also updated the tests. The natural logarithm is used instead of the logarithm base 10 (common logarithm) because this is only a constant scaling, which does not affect the relative ranking of diversity measures.

The numerical stability issue is explained in https://github.com/theochem/Selector/issues/229.