### PR TITLE
Fix failing `CodeCov` report

### DIFF
--- a/.github/workflows/ci_codecov.yml
+++ b/.github/workflows/ci_codecov.yml
@@ -65,7 +65,7 @@ jobs:
     - name: CodeCov
       uses: codecov/codecov-action@v4
       env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         fail_ci_if_error: true
         file: ./coverage.xml

--- a/.github/workflows/ci_codecov.yml
+++ b/.github/workflows/ci_codecov.yml
@@ -65,7 +65,9 @@ jobs:
     - name: CodeCov
       uses: codecov/codecov-action@v4
       with:
-        # token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }}
+        # Temp fix for https://github.com/codecov/codecov-action/issues/1487
+        version: v0.6.0
         fail_ci_if_error: true
         file: ./coverage.xml
         flags: unittests

--- a/.github/workflows/ci_codecov.yml
+++ b/.github/workflows/ci_codecov.yml
@@ -64,9 +64,8 @@ jobs:
 
     - name: CodeCov
       uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         file: ./coverage.xml
         flags: unittests

--- a/.github/workflows/ci_codecov.yml
+++ b/.github/workflows/ci_codecov.yml
@@ -65,7 +65,7 @@ jobs:
     - name: CodeCov
       uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        # token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         file: ./coverage.xml
         flags: unittests


### PR DESCRIPTION
This issue is discussed in https://github.com/codecov/codecov-action/issues/1487.
Two sample fixes, https://github.com/MFlowCode/MFC/pull/500 and https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/1686