### PR TITLE
Fix the KD-Tree query return

### DIFF
--- a/selector/methods/partition.py
+++ b/selector/methods/partition.py
@@ -443,6 +443,18 @@ class Medoid(SelectionBase):
             Index for the sample to start selection from; this index is the first sample selected.
         scaling: float
             Percent of average maximum distance to use when eliminating the closest points.
+
+        Notes
+        -----
+        The `Mediod` implementation is based on the KDTree algorithm and therefore can give
+        different results for cases with duplicated points or the same features for differenr
+        objects in the original feature space. This is dicussed in
+        https://github.com/theochem/Selector/issues/238.
+        This is because the same features lead to the same distances in the tree, and this is a
+        known issue of sorting the points and indices in the KDTree algorithm, as discussed
+        in https://github.com/scipy/scipy/issues/19029. Therefore, precautions should be taken if
+        duplicated points are present in the dataset.
+
         """
 
         self.starting_idx = ref_index

--- a/selector/methods/partition.py
+++ b/selector/methods/partition.py
@@ -518,6 +518,11 @@ class Medoid(SelectionBase):
         _, elim_candidates = tree.query(
             point, k=self.ratio, distance_upper_bound=np.sqrt(threshold), workers=-1
         )
+        # elim_candidates can be integer or array of integers
+        # https://github.com/scipy/scipy/blob/a2a287d1f7c81154256ba742b4b8bb108a612166/scipy/spatial/_kdtree.py#L476
+        if isinstance(elim_candidates, np.intp):
+            elim_candidates = [elim_candidates]
+
         if num_eliminate < 0:
             elim_candidates = elim_candidates[:num_eliminate]
         for index in elim_candidates:

--- a/selector/methods/partition.py
+++ b/selector/methods/partition.py
@@ -447,7 +447,7 @@ class Medoid(SelectionBase):
         Notes
         -----
         The `Mediod` implementation is based on the KDTree algorithm and therefore can give
-        different results for cases with duplicated points or the same features for differenr
+        different results for cases with duplicated points or the same features for different
         objects in the original feature space. This is dicussed in
         https://github.com/theochem/Selector/issues/238.
         This is because the same features lead to the same distances in the tree, and this is a

--- a/selector/methods/partition.py
+++ b/selector/methods/partition.py
@@ -473,7 +473,12 @@ class Medoid(SelectionBase):
             if len(points) == 0:
                 return None
             middle = len(points) // 2
-            indices, points = zip(*sorted(enumerate(points), key=lambda x: x[1][depth % k]))
+
+            # sort the points and indices
+            # indices, points = zip(*sorted(enumerate(points), key=lambda x: x[1][depth % k]))
+            indices = np.argsort(np.array(points)[:, depth % k], kind="stable")
+            points = np.array(points)[indices]
+
             if old_indices is not None:
                 indices = [old_indices[i] for i in indices]
             return self.BT(

--- a/selector/methods/tests/test_partition.py
+++ b/selector/methods/tests/test_partition.py
@@ -175,3 +175,9 @@ def test_medoid():
     selected_ids = selector.select(coords, size=12)
     # make sure all the selected indices are the same with expectation
     assert_equal(selected_ids, [0, 95, 57, 41, 25, 9, 8, 6, 66, 1, 42, 82])
+
+    # test the case where KD-Tree query return is an integer
+    features = np.array([[1.5, 2.8], [2.3, 3.8], [1.5, 2.8], [4.0, 5.9]])
+    selector = Medoid()
+    selected_ids = selector.select(features, size=2)
+    assert_equal(selected_ids, [0, 3])


### PR DESCRIPTION
The index of each neighbor of KD-Tree query results can be integer or array of integers. The original implementation works for the array of integers, but not including the integer case. This commit fixes the problem.

More explanations were provided in https://github.com/theochem/Selector/issues/236.