### PR TITLE
Enable the selection with predefined data points for `MaxMin`

### DIFF
--- a/selector/methods/distance.py
+++ b/selector/methods/distance.py
@@ -60,7 +60,7 @@ class MaxMin(SelectionBase):
     Structure‐Activity Relationships 21.6 (2002): 598-604.
     """
 
-    def __init__(self, fun_dist=None, ref_index="medoid"):
+    def __init__(self, fun_dist=None, ref_index=None):
         """
         Initializing class.
 
@@ -74,7 +74,7 @@ class MaxMin(SelectionBase):
             Index of the reference sample to start the selection algorithm from.
             It can be an integer, a float, a list of integers or floats or a mixture of them,
             or "medoid", or "None". When `None`, the medoid center is chosen as the reference
-            sample. Default is "medoid".
+            sample. Default is "None".
 
         """
         self.fun_dist = fun_dist
@@ -151,7 +151,7 @@ class MaxSum(SelectionBase):
     symposium on Principles of Database Systems. 2012.
     """
 
-    def __init__(self, fun_dist=None):
+    def __init__(self, fun_dist=None, ref_index=None):
         """
         Initializing class.
 
@@ -161,8 +161,15 @@ class MaxSum(SelectionBase):
             Function for calculating the pairwise distance between sample points.
             `fun_dist(x) -> x_dist` takes a 2D feature array of shape (n_samples, n_features)
             and returns a 2D distance array of shape (n_samples, n_samples).
+        ref_index: int, str, list, optional
+            Index of the reference sample to start the selection algorithm from.
+            It can be an integer, a float, a list of integers or floats or a mixture of them,
+            or "medoid", or "None". When `None`, the medoid center is chosen as the reference
+            sample. Default is "None".
+
         """
         self.fun_dist = fun_dist
+        self.ref_index = ref_index
 
     def select_from_cluster(self, x, size, labels=None):
         """Return selected samples from a cluster based on MaxSum algorithm.
@@ -182,12 +189,8 @@ class MaxSum(SelectionBase):
         -------
         selected : list
             List of indices of selected samples.
-        """
-        if size > len(x):
-            raise ValueError(
-                f"Given size is greater than the number of sample points, {size} > {len(x)} "
-            )
 
+        """
         # calculate pairwise distance between points
         x_dist = x
         if self.fun_dist is not None:
@@ -203,9 +206,8 @@ class MaxSum(SelectionBase):
             # that only contains pairwise distances between samples within a given cluster.
             x_dist = x_dist[labels][:, labels]
 
-        # choosing initial point as the medoid (i.e., point with minimum cumulative pairwise
-        # distances to other points)
-        selected = [np.argmin(np.sum(x_dist, axis=0))]
+        # setting up initial point
+        selected = setup_reference_index(x_dist=x_dist, ref_index=self.ref_index)
         # select following points until desired number of points have been obtained
         while len(selected) < size:
             # determine sum of pairwise distances between selected points and all other points

--- a/selector/methods/tests/test_distance.py
+++ b/selector/methods/tests/test_distance.py
@@ -126,6 +126,21 @@ def test_maxmin():
     assert_equal(selected_mocked, [0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 15, 10, 13, 9, 18])
 
 
+def test_maxmin_invalid_input():
+    """Testing MaxMin class with invalid input."""
+    # case when the distance matrix is not square
+    x_dist = np.array([[0, 1], [1, 0], [4, 9]])
+    with pytest.raises(ValueError):
+        collector = MaxMin(ref_index=0)
+        _ = collector.select(x_dist, size=2)
+
+    # case when the distance matrix is not symmetric
+    x_dist = np.array([[0, 1, 2], [1, 0, 3], [4, 9, 0], [5, 6, 7]])
+    with pytest.raises(ValueError):
+        collector = MaxMin(ref_index=0)
+        _ = collector.select(x_dist, size=2)
+
+
 def test_maxsum_clustered_data():
     """Testing MaxSum class."""
     # generate random data points belonging to multiple clusters - coordinates and class labels
@@ -204,6 +219,21 @@ def test_maxsum_non_clustered_data():
             fun_dist=lambda x: pairwise_distances(x, metric="euclidean"), ref_index=-1
         )
         selected_ids = collector.select(coords, size=12)
+
+
+def test_maxsum_invalid_input():
+    """Testing MaxSum class with invalid input."""
+    # case when the distance matrix is not square
+    x_dist = np.array([[0, 1], [1, 0], [4, 9]])
+    with pytest.raises(ValueError):
+        collector = MaxSum(ref_index=0)
+        _ = collector.select(x_dist, size=2)
+
+    # case when the distance matrix is not symmetric
+    x_dist = np.array([[0, 1, 2], [1, 0, 3], [4, 9, 0], [5, 6, 7]])
+    with pytest.raises(ValueError):
+        collector = MaxSum(ref_index=0)
+        _ = collector.select(x_dist, size=2)
 
 
 def test_optisim():

--- a/selector/methods/tests/test_distance.py
+++ b/selector/methods/tests/test_distance.py
@@ -72,7 +72,7 @@ def test_maxmin():
     assert_equal(selected_ids_medoid_1, [85, 57, 41, 25, 9, 62, 29, 65, 81, 61, 60, 97])
 
     # use MaxMin algorithm to select points from non-clustered data with "None" for the reference point
-    collector_medoid_2 = MaxMin(ref_index=None)
+    collector_medoid_2 = MaxMin(ref_index="medoid")
     selected_ids_medoid_2 = collector_medoid_2.select(arr_dist, size=12)
     # make sure all the selected indices are the same with expectation
     assert_equal(selected_ids_medoid_2, [85, 57, 41, 25, 9, 62, 29, 65, 81, 61, 60, 97])
@@ -139,13 +139,15 @@ def test_maxsum_clustered_data():
     )
 
     # use MaxSum algorithm to select points from clustered data, instantiating with euclidean distance metric
-    collector = MaxSum(lambda x: pairwise_distances(x, metric="euclidean"))
+    collector = MaxSum(
+        fun_dist=lambda x: pairwise_distances(x, metric="euclidean"), ref_index="medoid"
+    )
     selected_ids = collector.select(coords_cluster, size=12, labels=class_labels_cluster)
     # make sure all the selected indices are the same with expectation
     assert_equal(selected_ids, [41, 34, 85, 94, 51, 50, 78, 66, 21, 64, 0, 83])
 
     # use MaxSum algorithm to select points from clustered data without instantiating with euclidean distance metric
-    collector = MaxSum()
+    collector = MaxSum(ref_index="medoid")
     selected_ids = collector.select(coords_cluster_dist, size=12, labels=class_labels_cluster)
     # make sure all the selected indices are the same with expectation
     assert_equal(selected_ids, [41, 34, 85, 94, 51, 50, 78, 66, 21, 64, 0, 83])
@@ -169,7 +171,9 @@ def test_maxsum_non_clustered_data():
         random_state=42,
     )
     # use MaxSum algorithm to select points from non-clustered data, instantiating with euclidean distance metric
-    collector = MaxSum(fun_dist=lambda x: pairwise_distances(x, metric="euclidean"), ref_index=None)
+    collector = MaxSum(
+        fun_dist=lambda x: pairwise_distances(x, metric="euclidean"), ref_index="medoid"
+    )
     selected_ids = collector.select(coords, size=12)
     # make sure all the selected indices are the same with expectation
     assert_equal(selected_ids, [85, 57, 25, 41, 95, 9, 21, 8, 13, 68, 37, 54])

--- a/selector/methods/tests/test_distance.py
+++ b/selector/methods/tests/test_distance.py
@@ -126,18 +126,8 @@ def test_maxmin():
     assert_equal(selected_mocked, [0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 15, 10, 13, 9, 18])
 
 
-def test_maxsum():
+def test_maxsum_clustered_data():
     """Testing MaxSum class."""
-    # generate random data points belonging to one cluster - coordinates
-    coords, _, _ = generate_synthetic_data(
-        n_samples=100,
-        n_features=2,
-        n_clusters=1,
-        pairwise_dist=True,
-        metric="euclidean",
-        random_state=42,
-    )
-
     # generate random data points belonging to multiple clusters - coordinates and class labels
     coords_cluster, class_labels_cluster, coords_cluster_dist = generate_synthetic_data(
         n_samples=100,
@@ -166,11 +156,50 @@ def test_maxsum():
             coords_cluster, size=101, labels=class_labels_cluster
         )
 
+
+def test_maxsum_non_clustered_data():
+    """Testing MaxSum class with non-clustered data."""
+    # generate random data points belonging to one cluster - coordinates
+    coords, _, _ = generate_synthetic_data(
+        n_samples=100,
+        n_features=2,
+        n_clusters=1,
+        pairwise_dist=True,
+        metric="euclidean",
+        random_state=42,
+    )
     # use MaxSum algorithm to select points from non-clustered data, instantiating with euclidean distance metric
-    collector = MaxSum(lambda x: pairwise_distances(x, metric="euclidean"))
+    collector = MaxSum(fun_dist=lambda x: pairwise_distances(x, metric="euclidean"), ref_index=None)
     selected_ids = collector.select(coords, size=12)
     # make sure all the selected indices are the same with expectation
     assert_equal(selected_ids, [85, 57, 25, 41, 95, 9, 21, 8, 13, 68, 37, 54])
+
+    # use MaxSum algorithm to select points from non-clustered data, instantiating with euclidean
+    # distance metric and using "medoid" as the reference point
+    collector = MaxSum(
+        fun_dist=lambda x: pairwise_distances(x, metric="euclidean"), ref_index="medoid"
+    )
+    selected_ids = collector.select(coords, size=12)
+    # make sure all the selected indices are the same with expectation
+    assert_equal(selected_ids, [85, 57, 25, 41, 95, 9, 21, 8, 13, 68, 37, 54])
+
+    # use MaxSum algorithm to select points from non-clustered data, instantiating with euclidean
+    # distance metric and using a list as the reference points
+    collector = MaxSum(
+        fun_dist=lambda x: pairwise_distances(x, metric="euclidean"),
+        ref_index=[85, 57, 25, 41, 95],
+    )
+    selected_ids = collector.select(coords, size=12)
+    # make sure all the selected indices are the same with expectation
+    assert_equal(selected_ids, [85, 57, 25, 41, 95, 9, 21, 8, 13, 68, 37, 54])
+
+    # use MaxSum algorithm to select points from non-clustered data, instantiating with euclidean
+    # distance metric and using an invalid reference point
+    with pytest.raises(ValueError):
+        collector = MaxSum(
+            fun_dist=lambda x: pairwise_distances(x, metric="euclidean"), ref_index=-1
+        )
+        selected_ids = collector.select(coords, size=12)
 
 
 def test_optisim():

--- a/selector/methods/tests/test_distance.py
+++ b/selector/methods/tests/test_distance.py
@@ -135,7 +135,7 @@ def test_maxmin_invalid_input():
         _ = collector.select(x_dist, size=2)
 
     # case when the distance matrix is not symmetric
-    x_dist = np.array([[0, 1, 2], [1, 0, 3], [4, 9, 0], [5, 6, 7]])
+    x_dist = np.array([[0, 1, 2, 1], [1, 1, 0, 3], [4, 9, 4, 0], [6, 5, 6, 7]])
     with pytest.raises(ValueError):
         collector = MaxMin(ref_index=0)
         _ = collector.select(x_dist, size=2)
@@ -229,8 +229,14 @@ def test_maxsum_invalid_input():
         collector = MaxSum(ref_index=0)
         _ = collector.select(x_dist, size=2)
 
-    # case when the distance matrix is not symmetric
+    # case when the distance matrix is not square
     x_dist = np.array([[0, 1, 2], [1, 0, 3], [4, 9, 0], [5, 6, 7]])
+    with pytest.raises(ValueError):
+        collector = MaxSum(ref_index=0)
+        _ = collector.select(x_dist, size=2)
+
+    # case when the distance matrix is not symmetric
+    x_dist = np.array([[0, 1, 2, 1], [1, 1, 0, 3], [4, 9, 4, 0], [6, 5, 6, 7]])
     with pytest.raises(ValueError):
         collector = MaxSum(ref_index=0)
         _ = collector.select(x_dist, size=2)
@@ -270,12 +276,17 @@ def test_optisim():
     # make sure all the selected indices are the same with expectation
     assert_equal(selected_ids, [0, 8, 55, 37, 41, 13, 12, 42, 6, 30, 57, 76])
 
-    # tester to check if OptiSim gives same results as MaxMin for k=>infinity
+    # check if OptiSim gives same results as MaxMin for k=>infinity
     collector = OptiSim(ref_index=85, k=999999)
     selected_ids_optisim = collector.select(coords, size=12)
     collector = MaxMin()
     selected_ids_maxmin = collector.select(arr_dist, size=12)
     assert_equal(selected_ids_optisim, selected_ids_maxmin)
+
+    # test with invalid ref_index
+    with pytest.raises(ValueError):
+        collector = OptiSim(ref_index=10000)
+        _ = collector.select(coords, size=12)
 
 
 def test_directed_sphere_size_error():

--- a/selector/methods/tests/test_distance.py
+++ b/selector/methods/tests/test_distance.py
@@ -65,11 +65,48 @@ def test_maxmin():
     # make sure all the selected indices are the same with expectation
     assert_equal(selected_ids, [85, 57, 41, 25, 9, 62, 29, 65, 81, 61, 60, 97])
 
+    # use MaxMin algorithm to select points from non-clustered data with "medoid" as the reference point
+    collector_medoid_1 = MaxMin(ref_index="medoid")
+    selected_ids_medoid_1 = collector_medoid_1.select(arr_dist, size=12)
+    # make sure all the selected indices are the same with expectation
+    assert_equal(selected_ids_medoid_1, [85, 57, 41, 25, 9, 62, 29, 65, 81, 61, 60, 97])
+
+    # use MaxMin algorithm to select points from non-clustered data with "None" for the reference point
+    collector_medoid_2 = MaxMin(ref_index=None)
+    selected_ids_medoid_2 = collector_medoid_2.select(arr_dist, size=12)
+    # make sure all the selected indices are the same with expectation
+    assert_equal(selected_ids_medoid_2, [85, 57, 41, 25, 9, 62, 29, 65, 81, 61, 60, 97])
+
+    # use MaxMin algorithm to select points from non-clustered data with float as the reference point
+    collector_float = MaxMin(ref_index=85.0)
+    selected_ids_float = collector_float.select(arr_dist, size=12)
+    # make sure all the selected indices are the same with expectation
+    assert_equal(selected_ids_float, [85, 57, 41, 25, 9, 62, 29, 65, 81, 61, 60, 97])
+
+    # use MaxMin algorithm to select points from non-clustered data with a predefined list as the reference point
+    collector_float = MaxMin(ref_index=[85, 57, 41, 25])
+    selected_ids_float = collector_float.select(arr_dist, size=12)
+    # make sure all the selected indices are the same with expectation
+    assert_equal(selected_ids_float, [85, 57, 41, 25, 9, 62, 29, 65, 81, 61, 60, 97])
+
+    # test failing case when ref_index is not a valid index
+    with pytest.raises(ValueError):
+        collector_float = MaxMin(ref_index=-3)
+        selected_ids_float = collector_float.select(arr_dist, size=12)
+    # test failing case when ref_index contains a complex number
+    with pytest.raises(ValueError):
+        collector_float = MaxMin(ref_index=[1 + 5j, 2, 5])
+        selected_ids_float = collector_float.select(arr_dist, size=12)
+    # test failing case when ref_index contains a negative number
+    with pytest.raises(ValueError):
+        collector_float = MaxMin(ref_index=[-1, 2, 5])
+        selected_ids_float = collector_float.select(arr_dist, size=12)
+
     # use MaxMin algorithm, this time instantiating with a distance metric
-    collector = MaxMin(lambda x: pairwise_distances(x, metric="euclidean"))
+    collector = MaxMin(fun_dist=lambda x: pairwise_distances(x, metric="euclidean"))
     simple_coords = np.array([[0, 0], [2, 0], [0, 2], [2, 2], [-10, -10]])
     # provide coordinates rather than pairwise distance matrix to collector
-    selected_ids = collector.select(simple_coords, size=3)
+    selected_ids = collector.select(x=simple_coords, size=3)
     # make sure all the selected indices are the same with expectation
     assert_equal(selected_ids, [0, 4, 3])
 


### PR DESCRIPTION
The original implementation does not support initial data points but only the medoid. Now we support 

- an integer
- an float
- None, which uses the medoid 
- a list of integer or float numbers or a mixture of both

This is achieved by having a shared function called `setup_reference_index`.