### PR TITLE
Fix Github action workflow lint errors

### DIFF
--- a/.github/workflows/ci_tox.yaml
+++ b/.github/workflows/ci_tox.yaml
@@ -29,9 +29,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         # https://github.com/actions/setup-python/issues/875
         exclude:
-          - os: macOS-latest
+          - os: macos-latest
             python-version: "3.9"
-          - os: macOS-latest
+          - os: macos-latest
             python-version: "3.10"
 
     steps:


### PR DESCRIPTION
I ran the `actionlint` command and it identified some issues in the workflow. This PR resolves those issues and ensures the workflows run reliably across all environments.

### Changes
- Replaced `macos-latest` with `macOS-latest` in `ci_tox.yaml` in matrix exclusion to match the defined matrix values.
- Upgraded version of `peaceiris/actions-gh-pages` from `v3` to `v4` in `website_auto.yaml` to make it compatible with GitHub Actions.

### Result
All workflows pass `actionlint`.