### PR TITLE
Fix: Restrict jupyter-book version to restore website deployment

### DIFF
--- a/book/content/requirements.txt
+++ b/book/content/requirements.txt
@@ -1,5 +1,5 @@
 docutils<0.18
 ghp-import
-jupyter-book
+jupyter-book<2
 matplotlib
 numpy


### PR DESCRIPTION
I have noticed that https://selector.qcdevs.org is not opening, and It is giving  a `404 Error`.

<img width="859" height="556" alt="Screenshot 2026-02-22 at 3 36 21 AM" src="https://github.com/user-attachments/assets/b363114a-0851-4015-ad58-45d412767277" />

This is because `v2.x` of `jupyter-book` introduces a new  build system which isn’t compatible with the present Sphinx configuration files, `book/content/_config.yml`, and `book/content/_toc.yml`.

Because `book/content/requirements.txt` doesn’t state a version maximum, `pip install -r book/content/requirements.txt` installs the latest v2.x, which then prevents the build.

This PR fixes the issue by restricting `jupyter-book` to a version under `<2` in `book/content/requirements.txt`.

### Verification
`jupyter-book build ./book/content` now runs without a problem, and no longer shows the EISDIR error.